### PR TITLE
Fix titles in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,23 @@
 # React + Mobx
 
 
-##Setup
+## Setup
 
-###Install node
+### Install node
   
   Install NVM: `curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.1/install.sh | bash`
   
   Install node : `nvm install 6.9.1`
 
-###Install yarn
+### Install yarn
 
  `npm install -g yarn`
 
-###Install dependencies
+### Install dependencies
 
  `yarn`
 
 
-##Use
+## Use
 
  `yarn start`


### PR DESCRIPTION
The spaces between # character and first word initial  were missing.
This was preventing markdown to be rendered as expected.

This commit fixes this problem.